### PR TITLE
scripts/dump_fs: fix config variable substitution

### DIFF
--- a/sd_card/custom/scripts/dump_fs.sh
+++ b/sd_card/custom/scripts/dump_fs.sh
@@ -2,6 +2,7 @@
 
 SD_DIR="/tmp/sd"
 CUSTOM_DIR="${SD_DIR}/custom"
+CONFIG_DIR="${CUSTOM_DIR}/configs"
 DUMP_ROOT_DIR="${SD_DIR}/dump"
 DATETIME="$(date +%Y%m%d_%H%M%S)"
 DUMP_DIR="${DUMP_ROOT_DIR}/${DATETIME}"
@@ -54,14 +55,14 @@ run_dump() {
 }
 
 run_dump_once() {
-    if [ "${DUMP_F ORCE}" = "1" ]; then
+    if [ "${DUMP_FORCE}" = "1" ]; then
         log "DUMP_FORCE=1: running dump_fs.sh"
     else
         if [ -f "${DUMP_MARKER}" ]; then
-            log "DUMP=1 but dump already done (${DUMP_MARKER}); skipping"
+            log "DUMP_FORCE=1 but dump already done (${DUMP_MARKER}); skipping"
             return 0
         fi
-        log "DUMP=1: running dump_fs.sh (first time)"
+        log "DUMP_FORCE=1: running dump_fs.sh (first time)"
     fi
     run_dump
     rc=$?


### PR DESCRIPTION
DUMP_FORCE flag could not be respected because CONFIG_DIR was not defined. Further, there was an extra space in later variable sub.